### PR TITLE
Fix an issue with `scs` and other minor changes

### DIFF
--- a/roles/gNB/tasks/start.yml
+++ b/roles/gNB/tasks/start.yml
@@ -23,7 +23,7 @@
 
 - name: create {{ srsran.docker.container.gnb_image }} containers
   community.docker.docker_container:
-    name: "rfsim5g-srsran-gnb"
+    name: "srsran-gnb"
     image: "{{ srsran.docker.container.gnb_image }}"
     networks:
       - name: "{{ srsran.docker.network.name }}"

--- a/roles/gNB/tasks/stop.yml
+++ b/roles/gNB/tasks/stop.yml
@@ -2,7 +2,7 @@
 
 - name: delete {{ srsran.docker.container.gnb_image }} container
   community.docker.docker_container:
-    name: "rfsim5g-srsran-gnb"
+    name: "srsran-gnb"
     state: absent
   when: inventory_hostname in groups['srsran_nodes']
   become: true

--- a/roles/gNB/templates/gnb_uhd.conf
+++ b/roles/gNB/templates/gnb_uhd.conf
@@ -29,22 +29,22 @@ cell_cfg:
   dl_arfcn: 632628                  # ARFCN of the downlink carrier (center frequency).
   band: 78                           # The NR band.
   channel_bandwidth_MHz: 20         # Bandwith in MHz. Number of PRBs will be automatically derived.
-  common_scs: 15                    # Subcarrier spacing in kHz used for data.
+  common_scs: 30                    # Subcarrier spacing in kHz used for data.
   plmn: "20893"                     # PLMN broadcasted by the gNB.
   tac: 1                            # Tracking area code (needs to match the core configuration).
   pci: 1
 
 log:
-  filename: stdout
-  all_level: info
-  mac_level: debug
-  du_level: info
-  rrc_level: debug
+  filename: stdout                  # Path of the log file.
+  all_level: warning                # Logging level applied to all layers.
+  mac_level: warning                # Logging level applied to MAC layer.
+  du_level: info                    # Logging level applied to DU entity.
+  rrc_level: info                   # Logging level applied to RRC layer.
 
 pcap:
-  mac_enable: false
-  mac_filename: /tmp/gnb_mac.pcap
-  ngap_enable: false
-  ngap_filename: /tmp/gnb_ngap.pcap
-  f1ap_enable: false
-  f1ap_filename: /tmp/gnb_f1ap.pcap
+  mac_enable: false                 # Set to true to enable MAC-layer PCAPs.
+  mac_filename: /tmp/gnb_mac.pcap   # Path where the MAC PCAP is stored.
+  ngap_enable: false                # Set to true to enable NGAP PCAPs.
+  ngap_filename: /tmp/gnb_ngap.pcap # Path where the NGAP PCAP is stored.
+  f1ap_enable: false                # Set to true to enable F1AP PCAPs.
+  f1ap_filename: /tmp/gnb_f1ap.pcap # Path where the F1AP PCAP is stored.


### PR DESCRIPTION
This PR fixes an issue with the `scs` value used by default. It also includes other minor changes regarding the name of the Docker container for the gNB and logging levels