### PR TITLE
Set privileged to true for the srsGNB container

### DIFF
--- a/roles/gNB/tasks/start.yml
+++ b/roles/gNB/tasks/start.yml
@@ -29,6 +29,7 @@
       - name: "{{ srsran.docker.network.name }}"
     volumes:
       - /tmp/gnb_zmq.conf:/opt/gnb_zmq.conf
+    privileged: true
     state: started
     detach: true
   when: inventory_hostname in groups['srsran_nodes']


### PR DESCRIPTION
When deploying with USRP, we do see some warnings due to insufficient privilege set for the container. In order to improve the performance we set the privileged flag to true for the srsGNB container.