### PR TITLE
Several improvements to srsRAN blueprint

### DIFF
--- a/roles/gNB/defaults/main.yml
+++ b/roles/gNB/defaults/main.yml
@@ -1,12 +1,12 @@
 srsran:
   docker:
     container:
-      gnb_image: aetherproject/srsran-gnb:rel-0.0.1
+      gnb_image: aetherproject/srsran-gnb:rel-0.2.0
     network:
       name: public_net
   simulation: true
   gnb:
-    conf_file: roles/gNB/templates/gnb_zmq.conf
+    conf_file: roles/gNB/templates/gnb_zmq.yaml
     ip: "172.20.0.2"
 
 core:

--- a/roles/gNB/tasks/start.yml
+++ b/roles/gNB/tasks/start.yml
@@ -7,17 +7,17 @@
   when: inventory_hostname in groups['srsran_nodes']
   become: true
 
-- name: remove /tmp/gnb_zmq.conf
+- name: remove /tmp/gnb_config.yaml
   file:
-    path: "/tmp/gnb_zmq.conf"
+    path: "/tmp/gnb_config.yaml"
     state: absent
   when: inventory_hostname in groups['srsran_nodes']
   become: true
 
-- name : copy gnb config file to /tmp/gnb_zmq.conf
+- name : copy gnb config file to /tmp/gnb_config.yaml
   template:
     src: "{{ ROOT_DIR }}/{{ srsran.gnb.conf_file }}"
-    dest: /tmp/gnb_zmq.conf
+    dest: /tmp/gnb_config.yaml
   when: inventory_hostname in groups['srsran_nodes']
   become: true
 
@@ -28,9 +28,10 @@
     networks:
       - name: "{{ srsran.docker.network.name }}"
     volumes:
-      - /tmp/gnb_zmq.conf:/opt/gnb_zmq.conf
+      - /tmp/gnb_config.yaml:/opt/gnb_config.yaml
     privileged: true
     state: started
     detach: true
+    command: "gnb -c /opt/gnb_config.yaml"
   when: inventory_hostname in groups['srsran_nodes']
   become: true

--- a/roles/gNB/tasks/stop.yml
+++ b/roles/gNB/tasks/stop.yml
@@ -7,17 +7,9 @@
   when: inventory_hostname in groups['srsran_nodes']
   become: true
 
-- name: remove /tmp/gnb_zmq.conf
+- name: remove /tmp/gnb_config.yaml
   file:
-    path: "/tmp/gnb_zmq.conf"
+    path: "/tmp/gnb_config.yaml"
     state: absent
-  when: inventory_hostname in groups['srsran_nodes']
-  become: true
-
-- name: remove {{ srsran.docker.container.gnb_image }} image
-  community.docker.docker_image:
-    name: "{{ srsran.docker.container.gnb_image }}"
-    state: absent
-    force_absent: true
   when: inventory_hostname in groups['srsran_nodes']
   become: true

--- a/roles/gNB/templates/gnb_uhd.yaml
+++ b/roles/gNB/templates/gnb_uhd.yaml
@@ -1,8 +1,3 @@
-# This configuration file example shows how to configure the srsRAN Project gNB to allow UE's to connect to it.
-# This specific example uses USRP for the RF-frontend, and creates an FDD cell with 10 MHz bandwidth.
-# To run the srsRAN Project gNB with this config, use the following command:
-#   sudo ./gnb -c gnb_uhd.yaml
-
 cu_cp:
   amf:
     addr: "{{ core.amf.ip }}"                 # The address or hostname of the AMF.
@@ -18,7 +13,7 @@ cu_cp:
 ru_sdr:
   device_driver: uhd                # The RF driver name.
   device_args: type=x300,addr=192.168.40.2,master_clock_rate=184.32e6,send_frame_size=8000,recv_frame_size=8000
-  srate: 23.04                      # RF sample rate might need to be adjusted according to selected bandwidth.
+  srate: 92.16                      # RF sample rate might need to be adjusted according to selected bandwidth.
   tx_gain: 20                       # Transmit gain of the RF might need to adjusted to the given situation.
   rx_gain: 25                       # Receive gain of the RF might need to adjusted to the given situation.
   clock: internal
@@ -27,8 +22,8 @@ ru_sdr:
 
 cell_cfg:
   dl_arfcn: 632628                  # ARFCN of the downlink carrier (center frequency).
-  band: 78                           # The NR band.
-  channel_bandwidth_MHz: 20         # Bandwith in MHz. Number of PRBs will be automatically derived.
+  band: 78                          # The NR band.
+  channel_bandwidth_MHz: 80         # Bandwith in MHz. Number of PRBs will be automatically derived.
   common_scs: 30                    # Subcarrier spacing in kHz used for data.
   plmn: "20893"                     # PLMN broadcasted by the gNB.
   tac: 1                            # Tracking area code (needs to match the core configuration).

--- a/roles/gNB/templates/gnb_zmq.yaml
+++ b/roles/gNB/templates/gnb_zmq.yaml
@@ -1,8 +1,3 @@
-# This configuration file example shows how to configure the srsRAN Project gNB to allow srsUE to connect to it.
-# This specific example uses ZMQ in place of a USRP for the RF-frontend, and creates an FDD cell with 10 MHz bandwidth.
-# To run the srsRAN Project gNB with this config, use the following command:
-#   sudo ./gnb -c gnb_zmq.yaml
-
 cu_cp:
   amf:
     addr: "{{ core.amf.ip }}"                 # The address or hostname of the AMF.
@@ -39,6 +34,10 @@ cell_cfg:
       dci_format_0_1_and_1_1: false # Set correct DCI format (fallback)
   prach:
     prach_config_index: 1           # Sets PRACH config to match what is expected by srsUE
+  pdsch:
+    mcs_table: qam64                # Sets PDSCH MCS to 64 QAM
+  pusch:
+    mcs_table: qam64                # Sets PUSCH MCS to 64 QAM
 
 log:
   filename: stdout                  # Path of the log file.

--- a/roles/uEsimulator/defaults/main.yml
+++ b/roles/uEsimulator/defaults/main.yml
@@ -1,7 +1,7 @@
 srsran:
   docker:
     container:
-      ue_image: aetherproject/srsran-ue:rel-0.0.1
+      ue_image: aetherproject/srsran-ue:rel-0.2.0
     network:
       name: public_net
 

--- a/roles/uEsimulator/tasks/stop.yml
+++ b/roles/uEsimulator/tasks/stop.yml
@@ -13,11 +13,3 @@
     state: absent
   when: inventory_hostname in groups['srsran_nodes'][0]
   become: true
-
-- name: remove {{ srsran.docker.container.ue_image }} image
-  community.docker.docker_image:
-    name: "{{ srsran.docker.container.ue_image }}"
-    state: absent
-    force_absent: true
-  when: inventory_hostname in groups['srsran_nodes'][0]
-  become: true

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,8 +1,8 @@
 srsran:
   docker:
     container:
-      gnb_image: aetherproject/srsran-gnb:rel-0.0.1
-      ue_image: aetherproject/srsran-ue:rel-0.0.1
+      gnb_image: aetherproject/srsran-gnb:rel-0.2.0
+      ue_image: aetherproject/srsran-ue:rel-0.2.0
     network:
       data_iface: data
       name: public_net
@@ -11,7 +11,7 @@ srsran:
         name: rfsim5g-public
   simulation: true
   gnb:
-    conf_file: gnb_zmq.conf
+    conf_file: gnb_zmq.yaml
     ip: "172.20.0.2"
   ue:
     conf_file: ue_zmq.conf


### PR DESCRIPTION
This PRs includes the following improvements:
- Use a newer Docker image for srsRAN gNB that can work in simulation mode (i.e., ZMQ mode), over-the-air signals using USRPs (UHD mode) and over-the-air signals using split 7.2/RUs (DPDK mode)
- Change extension of gNB configuration files from `conf` to `yaml` because they are actually yaml files
- Avoid removing the Docker image during uninstall such that the deployment process takes less time next time that the container gets deployed
- Update `gnb_zmq` configuration file based on the latest updates from srsRAN
- Update default configuration for `gnb_uhd` such that higher throughput is achieved when using USRPs (e.g., X310)

These changes were tested in simulation mode and with over-the-air transmissions using an USRP X310 and connecting a Pixel 7a phone